### PR TITLE
Call finalize on gbsa forces

### DIFF
--- a/parmed/structure.py
+++ b/parmed/structure.py
@@ -2932,6 +2932,11 @@ class Structure(object):
                                  'should not be here')
         for atom, parms in zip(self.atoms, gb_parms):
             force.addParticle([atom.charge] + list(parms))
+        try:
+            force.finalize()
+        except AttributeError:
+            # only new versions of omm require calling finalize
+            pass
         # Set cutoff method
         if nonbondedMethod is app.NoCutoff:
             force.setNonbondedMethod(mm.CustomGBForce.NoCutoff)


### PR DESCRIPTION
The amber custom gbsa forces now require calling `finalize` before use. This change adds this call, swallowing the resulting exception that occurs with older versions of openmm.

The call to finalize is needed because the optimized versions of `GBn` and `GBn2` cache the atom parameters in order to upload only the necessary values of `d0` and `m0`. The particles are only added to the force when `finalize` is called.
